### PR TITLE
fix: use bash builtin kill for server certificate reload

### DIFF
--- a/setup/setup_scripts/reload_server_https_certificate.sh
+++ b/setup/setup_scripts/reload_server_https_certificate.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Sending reload signal to server..."
 # The server is always PID 1 inside the container
-$CONTAINERMGR exec sandfly-server kill -HUP 1
+$CONTAINERMGR exec sandfly-server bash -c 'kill -HUP 1'
 
 if [ $? -eq 0 ]; then
     echo "Reload signal sent. The server will reload its TLS certificate."


### PR DESCRIPTION
## Problem

The `reload_server_https_certificate.sh` script fails when trying to
send a SIGHUP to the sandfly-server container. The container image
does not include a standalone `kill` binary, so `docker exec` can not
find it in $PATH and exits with:

  OCI runtime exec failed: exec failed: unable to start container
  process: exec: "kill": executable file not found in $PATH: unknown
```
Sending reload signal to server...
+ docker exec sandfly-server kill -HUP 1
OCI runtime exec failed: exec failed: unable to start container process: exec: "kill": executable file not found in $PATH: unknown
+ '[' 126 -eq 0 ']'
+ echo 'Failed to send reload signal.'
Failed to send reload signal.
```
## Fix

Replaced the direct `kill -HUP 1` call with `bash -c 'kill -HUP 1'`
so it uses the bash builtin instead, which is alredy available inside
the container.
```
Sending reload signal to server...
+ docker exec sandfly-server bash -c 'kill -HUP 1'
+ '[' 0 -eq 0 ']'
+ echo 'Reload signal sent. The server will reload its TLS certificate.'
Reload signal sent. The server will reload its TLS certificate.
```

## Testing

- Confirmed `kill` is not available as a standalone binary in the container
- Confirmed `bash -c 'kill -HUP 1'` works and the server reloads its TLS certificate succesfully